### PR TITLE
Feature: Link SuccessView Continue Button to CameraView

### DIFF
--- a/VideoJournal/MetaData.swift
+++ b/VideoJournal/MetaData.swift
@@ -8,27 +8,34 @@
 import SwiftUI
 
 struct MetaData: View {
-    
+    @State var journalTitle: String = ""
+    @State var journalDescription: String = ""
     var body: some View {
-        VStack {
-            
-            Image("cat")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .padding()
-            
-            Spacer()
-            
-            MetaDataRow(dataLabel: "Title", dataEntry: "My Video")
-            MetaDataRow(dataLabel: "Description", dataEntry: "Video Description")
-            
-            Spacer()
-            
-            Text("Upload")
-                .padding()
-                .border(/*@START_MENU_TOKEN@*/Color.black/*@END_MENU_TOKEN@*/)
-            
-            Spacer()
+        NavigationStack {
+            VStack {
+                
+                Image("cat")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .padding()
+                
+                Spacer()
+                
+                MetaDataRow(dataLabel: "Title", dataEntry: $journalTitle)
+                MetaDataRow(dataLabel: "Description", dataEntry: $journalDescription)
+                
+                Spacer()
+                
+                NavigationLink(destination: SuccessView(uploadedTitle: journalTitle)
+                    .navigationBarBackButtonHidden(true)) {
+                    Text("Upload")
+                        .padding()
+                    .border(/*@START_MENU_TOKEN@*/Color.black/*@END_MENU_TOKEN@*/)
+                }
+                .disabled(journalTitle.isEmpty) // Disable the button if journalTitle is empty
+                
+                Spacer()
+            }
         }
         
     }

--- a/VideoJournal/MetaDataRow.swift
+++ b/VideoJournal/MetaDataRow.swift
@@ -10,22 +10,29 @@ import SwiftUI
 struct MetaDataRow: View {
     
     var dataLabel:String
-    @State var dataEntry:String
+    @Binding var dataEntry:String
     
     var body: some View {
         HStack(alignment: .center) {
             Spacer()
             Text(dataLabel+":")
+                .font(.system(size: 20)) // Increase the font size
             Spacer()
             
             TextField(dataLabel, text: $dataEntry)
-                .padding(.leading)
+                .font(.system(size: 20)) // Increase the font size
+                .padding(10) // Increase the padding
                 .border(.secondary)
             Spacer()
         }
     }
 }
 
-#Preview {
-    MetaDataRow(dataLabel: "Title",dataEntry: "My Video")
+struct MetaDataRow_Previews: PreviewProvider {
+    @State static var previewDataEntry = "hi"
+    
+    static var previews: some View {
+        MetaDataRow(dataLabel: "Title", dataEntry: $previewDataEntry)
+    }
 }
+

--- a/VideoJournal/SuccessView.swift
+++ b/VideoJournal/SuccessView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct SuccessView: View {
+    var uploadedTitle: String = "hello world"
     var body: some View {
         NavigationView {
             ZStack {
@@ -18,8 +19,12 @@ struct SuccessView: View {
                     Image("shield-tick")
                         .resizable()
                         .frame(width: 200, height: 200)
-                    Text("Upload Success!")
-                        .font(.largeTitle)
+                    Text(uploadedTitle)
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .foregroundColor(.black)
+                    Text("was uploaded successfully!")
+                        .font(.subheadline)
                         .fontWeight(.bold)
                         .padding(.bottom, 300)
                         .foregroundColor(.black)


### PR DESCRIPTION
## Summary

The continue button now programmatically returns the user back to the CameraView

## Changes

- use navigationstack to redirect to CameraView
- changed the default background to white and text on screen to black

## Screenshots
It's a little slow...
<img src="https://github.com/jimjimrao/VideoJournal/assets/32654532/5e2f8ce3-f153-46a0-beca-49bec2936a03" alt="RPReplay_Final1701442699" width="300">

## Testing

Describe the testing you performed to verify your changes.

## Notes

Any additional notes or context you want to provide.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
