### PR TITLE
Feature: pass captured photo to metadata preview 

### DIFF
--- a/VideoJournal/CameraView.swift
+++ b/VideoJournal/CameraView.swift
@@ -183,7 +183,7 @@ struct CameraView: View {
             
             // Continue Button
             if !isRecording && viewModel.isTaken {
-                NavigationLink(destination: MetaData()) {
+                NavigationLink(destination: MetaData(capturedPhoto: viewModel.capturedPhoto)) {
                     Text("Continue")
                         .padding()
                         .foregroundColor(.white)

--- a/VideoJournal/CameraView.swift
+++ b/VideoJournal/CameraView.swift
@@ -141,7 +141,16 @@ struct CameraView: View {
                         isRecording = true
                     }
                 case .photo:
-                    viewModel.aespaSession.capturePhoto(autoVideoOrientationEnabled: true)
+                    viewModel.aespaSession.capturePhoto(autoVideoOrientationEnabled: true) { result in
+                        switch result {
+                        case .success(let photo):
+                            viewModel.capturedPhoto = photo // Assign the captured photo to the variable
+                            // Handle the captured photo or perform further actions
+                        case .failure(let error):
+                            print("Error capturing photo: \(error)")
+                            // Handle the error appropriately
+                        }
+                    }
                     viewModel.isTaken = true
                 }
             }

--- a/VideoJournal/CameraView.swift
+++ b/VideoJournal/CameraView.swift
@@ -144,7 +144,9 @@ struct CameraView: View {
                     viewModel.aespaSession.capturePhoto(autoVideoOrientationEnabled: true) { result in
                         switch result {
                         case .success(let photo):
-                            viewModel.capturedPhoto = photo // Assign the captured photo to the variable
+                            DispatchQueue.main.async {
+                                viewModel.capturedPhoto = photo // Assign the captured photo to the variable
+                            }
                             // Handle the captured photo or perform further actions
                         case .failure(let error):
                             print("Error capturing photo: \(error)")

--- a/VideoJournal/CameraViewModel.swift
+++ b/VideoJournal/CameraViewModel.swift
@@ -29,6 +29,9 @@ class CameraViewModel: ObservableObject {
     @Published var videoAlbumCover: Image?
     @Published var photoAlbumCover: Image?
     
+    @Published var capturedPhoto: PhotoFile?
+
+    
     @Published var videoFiles: [VideoAsset] = []
     @Published var photoFiles: [PhotoAsset] = []
     

--- a/VideoJournal/MetaData.swift
+++ b/VideoJournal/MetaData.swift
@@ -11,30 +11,33 @@ struct MetaData: View {
     
     var body: some View {
         NavigationView {
-            VStack {
-                
-                Image("cat")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .padding()
-                
-                Spacer()
-                
-                MetaDataRow(dataLabel: "Title", dataEntry: "My Video")
-                MetaDataRow(dataLabel: "Description", dataEntry: "Video Description")
-                
-                Spacer()
-                
-                NavigationLink(destination: SuccessView().navigationBarBackButtonHidden(true)) {
-                    Text("Continue")
+            GeometryReader { geometry in
+                VStack {
+                    
+                    Image("cat")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: geometry.size.width * 0.8, height: geometry.size.width * 0.8) // Set relative frame size
                         .padding()
-                        .foregroundColor(.white)
-                        .frame(maxWidth: 200)
-                        .background(Color.blue)
-                        .cornerRadius(10)
+                    
+                    Spacer()
+                    
+                    MetaDataRow(dataLabel: "Title", dataEntry: "My Video")
+                    MetaDataRow(dataLabel: "Description", dataEntry: "Video Description")
+                    
+                    Spacer()
+                    
+                    NavigationLink(destination: SuccessView().navigationBarBackButtonHidden(true)) {
+                        Text("Continue")
+                            .padding()
+                            .foregroundColor(.white)
+                            .frame(maxWidth: 200)
+                            .background(Color.blue)
+                            .cornerRadius(10)
+                    }
+                    
+                    Spacer()
                 }
-                
-                Spacer()
             }
         }
         

--- a/VideoJournal/MetaData.swift
+++ b/VideoJournal/MetaData.swift
@@ -6,21 +6,31 @@
 //
 
 import SwiftUI
+import Aespa
 
 struct MetaData: View {
+    var capturedPhoto: PhotoFile?
     
     var body: some View {
         NavigationView {
             GeometryReader { geometry in
                 VStack {
-                    
-                    Image("cat")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: geometry.size.width * 0.8, height: geometry.size.width * 0.8) // Set relative frame size
-                        .padding()
-                    
-                    Spacer()
+                    Group {
+                        if let photo = capturedPhoto {
+                            Image(uiImage: photo.image)
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                        } else {
+                            Text("No photo captured")
+                                .foregroundColor(.gray)
+                        }
+                    }
+                    .frame(width: geometry.size.width * 0.8, height: geometry.size.width * 0.8)
+                    .padding()
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(Color.black, lineWidth: 1)
+                    )
                     
                     MetaDataRow(dataLabel: "Title", dataEntry: "My Video")
                     MetaDataRow(dataLabel: "Description", dataEntry: "Video Description")
@@ -31,7 +41,6 @@ struct MetaData: View {
                         Text("Continue")
                             .padding()
                             .foregroundColor(.white)
-                            .frame(maxWidth: 200)
                             .background(Color.blue)
                             .cornerRadius(10)
                     }
@@ -40,7 +49,6 @@ struct MetaData: View {
                 }
             }
         }
-        
     }
 }
 


### PR DESCRIPTION
## Summary

Added functionality of the captured photo is viewed in the metadata preview

## Changes

| Has Photo  |  No Photo|
| ------------- | ------------- |
| <img src="https://github.com/jimjimrao/VideoJournal/assets/32654532/d1b91772-a455-4955-bffc-29de923242c5" alt="First GIF" width="200" style="margin-bottom: 10px;"> | <img src="https://github.com/jimjimrao/VideoJournal/assets/32654532/9882be04-3baf-4364-b76e-f993064bcc24" alt="Second GIF" width="200" style="margin-top: 10px;">  |


## Screenshots

Include screenshots or screen recordings if there are UI changes.

## Testing

Describe the testing you performed to verify your changes.

## Notes

Any additional notes or context you want to provide.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
