### PR TITLE
Refactor the image to be displayed on metadata page

### DIFF
--- a/VideoJournal/CameraView.swift
+++ b/VideoJournal/CameraView.swift
@@ -31,8 +31,7 @@ struct CameraView: View {
                 } else {
                     switch captureMode {
                     case .video:
-                        let takenVideo =
-                            viewModel.videoAlbumCover
+                        let takenVideo = viewModel.videoAlbumCover
                         
                         takenVideo?
                             .resizable()
@@ -205,7 +204,8 @@ struct CameraView: View {
             
             // Continue Button
             if !isRecording && viewModel.isTaken {
-                NavigationLink(destination: MetaData(capturedPhoto: viewModel.capturedPhoto)) {
+                let coverImage = ( captureMode == .video ? viewModel.videoAlbumCover : viewModel.photoAlbumCover) ?? Image("")
+                NavigationLink(destination: MetaData(capturedPhoto: coverImage)) {
                     Text("Continue")
                         .padding()
                         .foregroundColor(.white)

--- a/VideoJournal/MetaData.swift
+++ b/VideoJournal/MetaData.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import Aespa
 
 struct MetaData: View {
-    var capturedPhoto: PhotoFile?
+    var capturedPhoto: Image?
     @State private var title: String = ""
     
     var body: some View {
@@ -17,8 +17,8 @@ struct MetaData: View {
             GeometryReader { geometry in
                 VStack {
                     Group {
-                        if let photo = capturedPhoto {
-                            Image(uiImage: photo.image)
+                        if capturedPhoto != Image("") {
+                            capturedPhoto?
                                 .resizable()
                                 .aspectRatio(contentMode: .fit)
                         } else {


### PR DESCRIPTION
## Summary

Refactored the capturePhoto input in MetaData to be an Image? instead of PhotoFile?. 
This allows for the coverImage to be cleanly passed into MetaData.
Video thumbnail will now be displayed on MetaData screen.

## Changes

- File1.swift: Added function `functionName` to handle...
- File2.swift: Refactored `anotherFunction` to improve...
- ...

## Screenshots

Include screenshots or screen recordings if there are UI changes.

## Testing

Describe the testing you performed to verify your changes.

## Notes

Any additional notes or context you want to provide.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
