### PR TITLE
Feature: Video Playback on MetaData View

### DIFF
--- a/VideoJournal/CameraView.swift
+++ b/VideoJournal/CameraView.swift
@@ -199,7 +199,7 @@ struct CameraView: View {
             // Continue Button
             if !isRecording && viewModel.isTaken {
                 let coverImage = ( captureMode == .video ? viewModel.videoAlbumCover : viewModel.photoAlbumCover) ?? Image("")
-                NavigationLink(destination: MetadataView(viewModel: viewModel, capturedPhoto: coverImage)) {
+                NavigationLink(destination: MetadataView(viewModel: viewModel, mediaPreview: coverImage)) {
                     Text("Continue")
                         .padding()
                         .foregroundColor(.white)

--- a/VideoJournal/CameraViewModel.swift
+++ b/VideoJournal/CameraViewModel.swift
@@ -32,6 +32,7 @@ class CameraViewModel: ObservableObject {
     @Published var capturedVideoData: Data?
     @Published var capturedPhoto: PhotoFile?
     @Published var photoData: UIImage
+    @Published var filePath: URL?
     
     
     @Published var videoFiles: [VideoAsset] = []
@@ -70,6 +71,7 @@ class CameraViewModel: ObservableObject {
             .map { result -> Image? in
                 if case .success(let file) = result {
                     if let filePath = file.path {
+                        self.filePath = filePath
                         self.uploadType = .video
                         self.setCapturedVideoData(from: filePath)
                     }

--- a/VideoJournal/MetadataView.swift
+++ b/VideoJournal/MetadataView.swift
@@ -10,7 +10,7 @@ import AVKit
 
 struct MetadataView: View {
     @ObservedObject var viewModel = CameraViewModel()
-    var capturedPhoto: Image?
+    var mediaPreview: Image?
     @State private var title: String = ""
     @State private var player = AVPlayer()
     @State private var isPlayerPresented = false
@@ -20,7 +20,7 @@ struct MetadataView: View {
             GeometryReader { geometry in
                 VStack {
                     Group {
-                        if capturedPhoto != Image("") {
+                        if mediaPreview != Image("") {
                             Button(action: {
                                 if viewModel.uploadType == .video {
                                     if self.player.currentItem?.asset != AVAsset(url: viewModel.filePath!) {
@@ -29,7 +29,7 @@ struct MetadataView: View {
                                     isPlayerPresented.toggle()
                                 }
                             }) {
-                                capturedPhoto?
+                                mediaPreview?
                                     .resizable()
                                     .aspectRatio(contentMode: .fit)
                             }

--- a/VideoJournal/MetadataView.swift
+++ b/VideoJournal/MetadataView.swift
@@ -6,11 +6,14 @@
 
 import SwiftUI
 import Aespa
+import AVKit
 
 struct MetadataView: View {
     @ObservedObject var viewModel = CameraViewModel()
     var capturedPhoto: Image?
     @State private var title: String = ""
+    @State private var player = AVPlayer()
+    @State private var isPlayerPresented = false
     
     var body: some View {
         NavigationView {
@@ -18,9 +21,18 @@ struct MetadataView: View {
                 VStack {
                     Group {
                         if capturedPhoto != Image("") {
-                            capturedPhoto?
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
+                            Button(action: {
+                                if viewModel.uploadType == .video {
+                                    if self.player.currentItem?.asset != AVAsset(url: viewModel.filePath!) {
+                                        self.player.replaceCurrentItem(with: AVPlayerItem(url: viewModel.filePath!))
+                                    }
+                                    isPlayerPresented.toggle()
+                                }
+                            }) {
+                                capturedPhoto?
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                            }
                         } else {
                             Text("No photo captured")
                                 .foregroundColor(.gray)
@@ -55,10 +67,19 @@ struct MetadataView: View {
                     Spacer()
                 }
             }
+            .sheet(isPresented: $isPlayerPresented) {
+                VideoPlayer(player: player)
+                    .onDisappear {
+                        self.player.pause()
+                        self.player.replaceCurrentItem(with: nil)
+                    }
+            }
         }
     }
 }
 
-#Preview {
-    MetadataView()
+struct MetadataView_Previews: PreviewProvider {
+    static var previews: some View {
+        MetadataView()
+    }
 }


### PR DESCRIPTION

## Changes

This PR introduces changes to three files:
- **CameraView.swift**: 
  - renamed `capturedPhoto` to`mediaPreview`
- **CameraViewModel.swift**: 
  - Added filepath variable to be referenced for the AV Player
- **MetadataView.swift**: 
  - Updated the view to handle displaying a video preview if available using AVPlayer() from AVKit
  - renamed `capturedPhoto` to`mediaPreview`


## Screenshots

Include screenshots or screen recordings if there are UI changes.

## Testing

To verify these changes, the following testing was performed:
1. Take a video
2. Hit Continue Button.
3. Verified that the video preview functionality in `MetadataView` plays the video you recorded.

## Notes

- The PR enhances the user experience by improving media handling and preview functionality.
- Ensure all changes align with project requirements and coding standards.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
