### PR TITLE
Added sign out button

### DIFF
--- a/VideoJournal/CameraViewModel.swift
+++ b/VideoJournal/CameraViewModel.swift
@@ -22,6 +22,7 @@ class CameraViewModel: ObservableObject {
     @Published var userOAuth2Token: GIDToken?
     
     @Published var isTaken = false
+    @Published var isSignedIn: Bool = false
     
     private var subscription = Set<AnyCancellable>()
     
@@ -135,6 +136,8 @@ class CameraViewModel: ObservableObject {
                     // Save the signed-in user to the currentUser property
                     self.currentUser = signInResult.user
                     
+                    isSignedIn = true
+                    
                     // Print data
                     print("User profile:", self.currentUser!)
                     print("User ID: \(self.currentUser!.userID!)")
@@ -163,6 +166,7 @@ class CameraViewModel: ObservableObject {
                     }
                 }
             // If sign in succeeded, display the app's main content View.
+            
         }
     }
     

--- a/VideoJournal/SettingView.swift
+++ b/VideoJournal/SettingView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import AVFoundation
 import GoogleSignInSwift
+import GoogleSignIn
 
 struct SettingView: View {
     @ObservedObject var viewModel: CameraViewModel
@@ -25,19 +26,33 @@ struct SettingView: View {
     
     var body: some View {
         List {
-            Section(header: Text("Common")) {
-                if viewModel.currentUser?.profile == nil {
-                    GoogleSignInButton(action: viewModel.handleSignInButton)
+            Section(header: Text("Account")) {
+                if !viewModel.isSignedIn {
+                    GoogleSignInButton(action: {
+                        viewModel.handleSignInButton()
+                    })
                 } else {
                     let userProfile = viewModel.currentUser?.profile
-                    VStack(alignment: .leading) {
-                        Text(userProfile!.name)
-                            .font(.headline)
-                        Text(userProfile!.email)
-                            .font(.subheadline)
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(userProfile?.name ?? "No name")
+                                .font(.headline)
+                            Text(userProfile?.email ?? "No email")
+                                .font(.subheadline)
+                        }
+                        Spacer()
+                        Button(action: {
+                            GIDSignIn.sharedInstance.signOut()
+                            viewModel.isSignedIn = false
+                        }) {
+                            Text("Sign Out")
+                        }
                     }
                 }
-                
+            }
+            
+            
+            Section(header: Text("Common")) {
                 // New button to call checkAndRequestScope
                 Button("Check and Request Scope") {
                     if let currentUser = viewModel.currentUser,


### PR DESCRIPTION
## Summary

Once the user is signed in, they can now see their name, email, and a sign out button

## Changes

CameraViewModel.swift
- Added isSignedIn variable
- Set isSignedIn to true in handleSignInButton

SettingView.swift
- Display name, email, and sign out button when the user is signed in; otherwise, display the sign in button.

## Screenshots

When user is signed out: 
![IMG_6225](https://github.com/jimjimrao/VideoJournal/assets/150304482/505ead6e-faa0-4636-b4db-0f4ecd397b32)

When user is signed in:
![IMG_6224](https://github.com/jimjimrao/VideoJournal/assets/150304482/a6a4b763-b23a-4f34-8548-c4b55041e451)

## Testing

Describe the testing you performed to verify your changes.

## Notes

Any additional notes or context you want to provide.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
