### PR TITLE
Display loading screen after photo is taken

### DIFF
--- a/VideoJournal/CameraView.swift
+++ b/VideoJournal/CameraView.swift
@@ -24,17 +24,21 @@ struct CameraView: View {
                 } else {
                     switch captureMode {
                     case .video:
-                        let takenVideo = viewModel.videoAlbumCover
-                        
-                        takenVideo?
-                            .resizable()
-                            .scaledToFill()
+                        if let takenVideo = viewModel.videoAlbumCover {
+                            takenVideo
+                                .resizable()
+                                .scaledToFill()
+                        } else {
+                            Text("Loading...")
+                        }
                     case .photo:
-                        let takenPhoto = viewModel.capturedPhoto?.thumbnailImage
-                        
-                        takenPhoto?
-                            .resizable()
-                            .scaledToFill()
+                        if let takenPhoto = viewModel.capturedPhoto?.thumbnailImage {
+                            takenPhoto
+                                .resizable()
+                                .scaledToFill()
+                        } else {
+                            Text("Loading...")
+                        }
                     }
                     
                 }
@@ -97,7 +101,12 @@ struct CameraView: View {
     
     @ViewBuilder
     var retakeButton: some View {
-        Button(action: {viewModel.isTaken = false}, label: {
+        Button(action: {
+            viewModel.isTaken = false
+            viewModel.videoAlbumCover = nil
+            viewModel.capturedPhoto = nil
+            
+        }, label: {
             Image(systemName: "arrow.uturn.forward.circle")
                 .resizable()
                 .foregroundColor(.white)


### PR DESCRIPTION
## Summary

After taking a photo/video, the user will now see a loading screen until the new thumbnail image gets uploaded.

## Changes

- CameraView.swift
After the user presses the retake button, the thumnail images are set to nil, so that a loading screen will be displayed after a new photo gets taken.

## Screenshots

Include screenshots or screen recordings if there are UI changes.

## Testing

Describe the testing you performed to verify your changes.

## Notes

Any additional notes or context you want to provide.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
